### PR TITLE
Add support for VPN

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,9 @@
-LND_ONION_ADDRESS="<YOUR_LND_NODE_ONION_ADDRESS" # For example, xyzdasdsadsa.onion
+LND_ONION_ADDRESS=#"<YOUR_LND_NODE_ONION_ADDRESS>" For example, xyzdasdsadsa.onion, leave blank if using Wireguard VPN
+VPN_HOST=# <YOUR_HOST_IP> for you VPN client
 LND_TOR_PORT=8080 #Default LND REST port is 8080, in most cases you can leave this untouched
 LND_INVOICE_MACAROON_HEX="<YOUR_LND_INVOICE_HEX_HERE>"
 INTERNET_IDENTIFIER="<IDENTIFIER_HERE>" ## Add the value on the left side of your LNURL identifier for example if your LNURL identifier is "nabismo@nostpypy.lol" you would add "nabismo" here
-HEX_PUBKEY="4503baa127bdfd0b054384dc5ba82cb0e2a8367cbdb0629179f00db1a34caacc"
+HEX_PUBKEY=# <YOUR_NOSTR_HEX_PUBKEY> 
 DOMAIN="<YOUR_DOMAIN_HERE>" # For example nostpy.lol
 CONTACT=<YOUR_EMAIL_ADDRESS> #Enter your email address for the certbot command to get emails about your TLS certificate when it is near expiration
 NGINX_FILE_PATH=/etc/nginx/sites-available/default #Leave this untouched

--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
-LND_ONION_ADDRESS=#"<YOUR_LND_NODE_ONION_ADDRESS>" For example, xyzdasdsadsa.onion, leave blank if using Wireguard VPN
-VPN_HOST=# <YOUR_HOST_IP> for you VPN client
+LND_ONION_ADDRESS=''#"<YOUR_LND_NODE_ONION_ADDRESS>" For example, xyzdasdsadsa.onion, leave blank if using Wireguard VPN
+VPN_HOST=''# <YOUR_HOST_IP> for you VPN client
 LND_REST_PORT=8080 #Default LND REST port is 8080, in most cases you can leave this untouched
 LND_INVOICE_MACAROON_HEX="<YOUR_LND_INVOICE_HEX_HERE>"
 INTERNET_IDENTIFIER="<IDENTIFIER_HERE>" ## Add the value on the left side of your LNURL identifier for example if your LNURL identifier is "nabismo@nostpypy.lol" you would add "nabismo" here

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 LND_ONION_ADDRESS=#"<YOUR_LND_NODE_ONION_ADDRESS>" For example, xyzdasdsadsa.onion, leave blank if using Wireguard VPN
 VPN_HOST=# <YOUR_HOST_IP> for you VPN client
-LND_TOR_PORT=8080 #Default LND REST port is 8080, in most cases you can leave this untouched
+LND_REST_PORT=8080 #Default LND REST port is 8080, in most cases you can leave this untouched
 LND_INVOICE_MACAROON_HEX="<YOUR_LND_INVOICE_HEX_HERE>"
 INTERNET_IDENTIFIER="<IDENTIFIER_HERE>" ## Add the value on the left side of your LNURL identifier for example if your LNURL identifier is "nabismo@nostpypy.lol" you would add "nabismo" here
 HEX_PUBKEY=# <YOUR_NOSTR_HEX_PUBKEY> 

--- a/menu.py
+++ b/menu.py
@@ -26,8 +26,8 @@ def start_flask_server():
         print_color("\nStarting Zap Server", "33")
         subprocess.run(["python3", "-m", "venv", "zap_venv"], check=True)
         activate_cmd = ". zap_venv/bin/activate && "
-        #commands = ["tmux new-session -s zap_server -d python zap_server.py"]
-        commands = ["python zap_server.py"]
+        commands = ["tmux new-session -s zap_server -d python zap_server.py"]
+        #commands = ["python zap_server.py"]
         for cmd in commands:
             subprocess.run(["bash", "-c", activate_cmd + cmd], check=True)
 

--- a/menu.py
+++ b/menu.py
@@ -26,7 +26,8 @@ def start_flask_server():
         print_color("\nStarting Zap Server", "33")
         subprocess.run(["python3", "-m", "venv", "zap_venv"], check=True)
         activate_cmd = ". zap_venv/bin/activate && "
-        commands = ["tmux new-session -s zap_server -d python zap_server.py"]
+        #commands = ["tmux new-session -s zap_server -d python zap_server.py"]
+        commands = ["python zap_server.py"]
         for cmd in commands:
             subprocess.run(["bash", "-c", activate_cmd + cmd], check=True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.0.0
 requests==2.31.0
 PySocks==1.7.1
 python-dotenv==0.19.2
+ddtrace

--- a/setup_nginx.py
+++ b/setup_nginx.py
@@ -30,7 +30,7 @@ server {{
     
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
-        proxy_pass http://127.0.0.1:5000;
+        proxy_pass http://127.0.0.1:5555;
         proxy_http_version 1.1;
     }}
 }}

--- a/zap_server.py
+++ b/zap_server.py
@@ -33,7 +33,7 @@ def get_invoice(amount, description):
         VPN_PORT = 51820
 
         # Configure WireGuard VPN tunnel
-        url = f"https://{VPN_HOST}/v1/invoices"
+        url = f"https://{VPN_HOST}:43244/v1/invoices"
         headers = {"Grpc-Metadata-macaroon": LND_INVOICE_MACAROON_HEX}
 
         response = requests.post(

--- a/zap_server.py
+++ b/zap_server.py
@@ -33,7 +33,7 @@ def get_invoice(amount, description):
         VPN_PORT = 51820
 
         # Configure WireGuard VPN tunnel
-        url = f"https://{VPN_HOST}:43244/v1/invoices"
+        url = f"https://{VPN_HOST}:8080/v1/invoices"
         headers = {"Grpc-Metadata-macaroon": LND_INVOICE_MACAROON_HEX}
 
         response = requests.post(

--- a/zap_server.py
+++ b/zap_server.py
@@ -34,6 +34,8 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
+logger.debug(f"ONion os {LND_ONION_ADDRESS}, VPN is {VPN_HOST}")
+
 
 def make_http_request(url, headers, data):
     try:

--- a/zap_server.py
+++ b/zap_server.py
@@ -129,4 +129,4 @@ def lnurl_response():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=True, port=5555)

--- a/zap_server.py
+++ b/zap_server.py
@@ -46,7 +46,9 @@ def make_http_request(url, headers, data):
             verify=False,  # Disable SSL verification if needed
         )
         response.raise_for_status()
-        return response.json()
+        invoice_data = response.json()
+        logger.debug(f"Received invoice data: {invoice_data}")
+        return invoice_data["payment_request"]
     except requests.exceptions.RequestException as e:
         raise RuntimeError(f"Error making HTTP request: {e}")
 

--- a/zap_server.py
+++ b/zap_server.py
@@ -33,7 +33,7 @@ def get_invoice(amount, description):
         VPN_PORT = 51820
 
         # Configure WireGuard VPN tunnel
-        url = f"https://{VPN_HOST}:{VPN_PORT}/v1/invoices"
+        url = f"https://{VPN_HOST}/v1/invoices"
         headers = {"Grpc-Metadata-macaroon": LND_INVOICE_MACAROON_HEX}
 
         response = requests.post(

--- a/zap_server.py
+++ b/zap_server.py
@@ -129,4 +129,4 @@ def lnurl_response():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, port=5555)
+    app.run(debug=True, host='0.0.0.0', port=5555)

--- a/zap_server.py
+++ b/zap_server.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 def get_invoice(amount, description):
     try:
         # Replace these with your WireGuard VPN server's details
-        VPN_HOST = 'VPN_SERVER_IP'
+        VPN_HOST = LND_ONION_ADDRESS
         VPN_PORT = 51820
 
         # Configure WireGuard VPN tunnel

--- a/zap_server.py
+++ b/zap_server.py
@@ -14,7 +14,7 @@ app = Flask(__name__)
 
 load_dotenv()
 
-tracer.configure(hostname='127.0.0.1', port=8126)
+tracer.configure(hostname="127.0.0.1", port=8126)
 patch_all()
 
 LND_ONION_ADDRESS = os.getenv("LND_ONION_ADDRESS")
@@ -52,6 +52,7 @@ def make_http_request(url, headers, data):
     except requests.exceptions.RequestException as e:
         raise RuntimeError(f"Error making HTTP request: {e}")
 
+
 def get_invoice(amount, description):
     headers = {"Grpc-Metadata-macaroon": LND_INVOICE_MACAROON_HEX}
     data = {"value": amount, "memo": description}
@@ -72,7 +73,6 @@ def get_invoice(amount, description):
             raise ValueError("Tor or VPN variables not provided.")
     except Exception as e:
         raise RuntimeError(f"Error creating invoice: {e}")
-
 
 
 @app.route("/lnurl-pay", methods=["GET"])
@@ -133,4 +133,4 @@ def lnurl_response():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host='0.0.0.0', port=5555)
+    app.run(debug=True, host="0.0.0.0", port=5555)


### PR DESCRIPTION
* Added support for fetching invoice via VPN (still supports tor)
  * Decides where to fetch invoice from based on whether `VPN_HOST` or `LND_ONION_ADDRESS` is added as a environmental variable
* Added log directory
* Fixed port conflict with Datadog agent

